### PR TITLE
test: add category model unit tests with validateSync()

### DIFF
--- a/config/db.test.js
+++ b/config/db.test.js
@@ -7,7 +7,7 @@ describe("Database Configuration", () => {
   let consoleLogSpy;
 
   beforeEach(() => {
-    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => { });
   });
 
   afterEach(() => {
@@ -31,6 +31,7 @@ describe("Database Configuration", () => {
   });
 
   it("should handle connection errors gracefully", async () => {
+    // Lum Yi Ren Johannsen, A0273503L
     // ARRANGE
     const mockError = new Error("Connection failed");
     mongoose.connect.mockRejectedValueOnce(mockError);

--- a/jest.backend.config.js
+++ b/jest.backend.config.js
@@ -6,11 +6,11 @@ export default {
   testEnvironment: "node",
 
   // which test to run
-  testMatch: ["**/controllers/*.test.js", "**/config/*.test.js"],
+  testMatch: ["**/controllers/*.test.js", "**/config/*.test.js", "**/models/*.test.js"],
 
   // jest code coverage
   collectCoverage: true,
-  collectCoverageFrom: ["config/**", "controllers/categoryController.js"],
+  collectCoverageFrom: ["config/**", "controllers/categoryController.js", "models/categoryModel.js"],
   coverageThreshold: {
     global: {
       lines: 100,

--- a/models/categoryModel.js
+++ b/models/categoryModel.js
@@ -3,7 +3,7 @@ import mongoose from "mongoose";
 const categorySchema = new mongoose.Schema({
   name: {
     type: String,
-    // required: true,
+    required: true,
     // unique: true,
   },
   slug: {

--- a/models/categoryModel.test.js
+++ b/models/categoryModel.test.js
@@ -1,0 +1,36 @@
+import categoryModel from "./categoryModel.js";
+
+describe("Category Model Unit Tests", () => {
+
+  it("should validate successfully with a valid name and slug", () => {
+    // Lum Yi Ren Johannsen, A0273503L
+    // ARRANGE
+    const validCategory = new categoryModel({
+      name: "Electronics",
+      slug: "electronics"
+    });
+
+    // ACT
+    // validateSync() checks the schema rules synchronously without needing a DB connection
+    const err = validCategory.validateSync();
+
+    // ASSERT
+    expect(err).toBeUndefined();
+  });
+
+  it("should throw a validation error if 'name' is missing", () => {
+    // Lum Yi Ren Johannsen, A0273503L
+    // ARRANGE
+    const invalidCategory = new categoryModel({
+      slug: "no-name-category"
+    });
+
+    // ACT
+    const err = invalidCategory.validateSync();
+
+    // ASSERT
+    // We expect an error because the schema requires a 'name'
+    expect(err).toBeDefined();
+    expect(err.errors["name"]).toBeDefined();
+  });
+});


### PR DESCRIPTION
# Pull Request: Category model unit tests

## Summary
Adds unit tests for the Category Mongoose model using `validateSync()` so schema validation is tested in memory without a database connection, and updates backend Jest config to run model tests.

## Changes

- **`models/categoryModel.test.js`** (new)
  - **Valid name and slug:** Instantiates the model with `name` and `slug`, calls `validateSync()`, asserts no error.
  - **Missing name:** Instantiates with only `slug`, calls `validateSync()`, asserts validation error with `errors["name"]` defined.
  - Tests use AAA comments
  - No DB connection; validation is tested in isolation.

- **`models/categoryModel.js`**
  - Uncommented `required: true` on the `name` field so the "name is missing" test passes and the schema enforces required name.

- **`jest.backend.config.js`**
  - Added `**/models/*.test.js` to `testMatch` so `npm run test:backend` runs model tests.

## Testing
- `npm run test:backend -- --testPathPattern=categoryModel` — both category model tests pass.
