### PR TITLE
Fix flaky and broken MS2 integration tests

### DIFF
--- a/client/src/pages/HomePageIntegration.test.js
+++ b/client/src/pages/HomePageIntegration.test.js
@@ -75,9 +75,9 @@ describe("HomePage integration (useCategory + axios stub)", () => {
       // ASSERT
       await waitFor(() => {
         expect(screen.getByRole("checkbox", { name: /Electronics/i })).toBeInTheDocument();
+        expect(screen.getByRole("checkbox", { name: /Books/i })).toBeInTheDocument();
+        expect(screen.getAllByRole("checkbox")).toHaveLength(2);
       });
-      expect(screen.getByRole("checkbox", { name: /Books/i })).toBeInTheDocument();
-      expect(screen.getAllByRole("checkbox")).toHaveLength(2);
       expect(screen.getByText(/Filter By Category/i)).toBeInTheDocument();
       expect(screen.getByText(/All Products/i)).toBeInTheDocument();
     });

--- a/tests/integration/category/category.integration.test.js
+++ b/tests/integration/category/category.integration.test.js
@@ -38,6 +38,7 @@ const createFakeResponse = () => {
   res.status = jest.fn().mockReturnValue(res);
   res.send = jest.fn().mockReturnValue(res);
   res.json = jest.fn().mockReturnValue(res);
+  res.set = jest.fn().mockReturnValue(res);
   return res;
 };
 

--- a/tests/integration/payment/paymentIntegration.test.js
+++ b/tests/integration/payment/paymentIntegration.test.js
@@ -57,12 +57,6 @@ const createFakeResponse = () => {
   return res;
 };
 
-/** Wait for async order.save() (controller does not await) */
-const flushAsyncWork = async () => {
-  await new Promise((resolve) => setImmediate(resolve));
-  await new Promise((resolve) => setImmediate(resolve));
-};
-
 const waitForOrderByBuyer = async (buyerId, { timeoutMs = 5000 } = {}) => {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -94,7 +88,7 @@ describe("brainTreePaymentController (integration)", () => {
 
     // ACT
     await brainTreePaymentController(req, res);
-    await flushAsyncWork();
+
 
     // ASSERT
     expect(mockSale).toHaveBeenCalledWith(
@@ -134,7 +128,7 @@ describe("brainTreePaymentController (integration)", () => {
 
     // ACT
     await brainTreePaymentController(req, res);
-    await flushAsyncWork();
+
 
     // ASSERT
     expect(res.status).toHaveBeenCalledWith(500);


### PR DESCRIPTION
 ## Summary                                                                                       
  - Remove flaky `flushAsyncWork` (double `setImmediate`) from `paymentIntegration.test.js` — the
  existing `waitForOrderByBuyer` polling helper already handles the un-awaited `.save()` reliably    
  - Add `res.set` to fake response in `category.integration.test.js` — fixes 2 failing tests caused
  by `categoryController` calling `res.set("Cache-Control", ...)` on a mock that didn't have it      
  - Wrap checkbox assertions inside `waitFor` in `HomePageIntegration.test.js` for async safety    
                                                                                                     
  ## Test plan                                                                                     
  - [ ] `npm run test:integration` — all 8 category tests and 2 payment tests pass (was 3 failures   
  before)                                                                                            
  - [ ] `npm run test:frontend -- --testPathPattern="HomePageIntegration"` — all 3 tests pass