### PR TITLE
Add missing test:nft script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test:spike-frontend": "npx playwright test tests/nft/spike/spike-search-frontend.spec.js --config playwright.spike.config.mjs",
     "test:volume": "bash tests/volume/run-volume-tests.sh",
     "test:volume:seed": "node tests/volume/seed-data.js",
-    "test:volume:clean": "node tests/volume/seed-data.js --clean"
+    "test:volume:clean": "node tests/volume/seed-data.js --clean",
+    "test:nft": "jest --config jest.nft.config.js"
   },
   "keywords": [],
   "author": "RP",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:volume": "bash tests/volume/run-volume-tests.sh",
     "test:volume:seed": "node tests/volume/seed-data.js",
     "test:volume:clean": "node tests/volume/seed-data.js --clean",
-    "test:nft": "jest --config jest.nft.config.js"
+    "test:nft:recovery": "jest --config jest.nft.config.js"
   },
   "keywords": [],
   "author": "RP",


### PR DESCRIPTION
 ## Summary
  - Add `test:nft:recovery` script to `package.json` — was missing from PR #91 which added the
  recovery test files and jest config                                                                
  
  ## Test plan                                                                                       
  - [ ] `npm run test:nft:recovery` — runs all 8 recovery tests 