### PR TITLE
Fix un-awaited order save in brainTreePaymentController

### DIFF
--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -390,14 +390,19 @@ export const brainTreePaymentController = async (req, res) => {
           submitForSettlement: true,
         },
       },
-      function (error, result) {
+      async function (error, result) {
         if (result) {
-          const order = new orderModel({
-            products: cart,
-            payment: result,
-            buyer: req.user._id,
-          }).save();
-          res.json({ ok: true });
+          try {
+            await new orderModel({
+              products: cart,
+              payment: result,
+              buyer: req.user._id,
+            }).save();
+            res.json({ ok: true });
+          } catch (saveError) {
+            console.log(saveError);
+            res.status(500).send({ ok: false, error: "Order could not be saved" });
+          }
         } else {
           res.status(500).send(error);
         }

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -1479,7 +1479,7 @@ describe("Payment Controller Unit Tests", () => {
 
                 // ACT
                 await brainTreePaymentController(req, res);
-                await new Promise(setImmediate);
+                await new Promise((r) => setTimeout(r, 50));
 
                 // ASSERT
                 expect(mockSale).toHaveBeenCalledWith(
@@ -1504,11 +1504,43 @@ describe("Payment Controller Unit Tests", () => {
 
                 // ACT
                 await brainTreePaymentController(req, res);
-                await new Promise(setImmediate);
+                await new Promise((r) => setTimeout(r, 50));
 
                 // ASSERT
                 expect(res.status).toHaveBeenCalledWith(500);
                 expect(res.send).toHaveBeenCalledWith(fakeError);
+            });
+
+            it("should return 500 when order save fails after successful payment", async () => {
+                // Lum Yi Ren Johannsen, A0273503L
+                // ARRANGE
+                req.body = {
+                    nonce: "fake-nonce",
+                    cart: [{ price: 10 }, { price: 20 }],
+                };
+                const fakeResult = { success: true };
+                mockSale.mockImplementation((opts, callback) =>
+                    callback(null, fakeResult)
+                );
+
+                // Make the order save reject
+                const orderModel = (await import("../models/orderModel.js")).default;
+                const saveError = new Error("DB save failed");
+                orderModel.mockImplementation(() => ({
+                    save: jest.fn().mockRejectedValue(saveError),
+                }));
+                const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+                // ACT
+                await brainTreePaymentController(req, res);
+                await new Promise((r) => setTimeout(r, 50));
+
+                // ASSERT
+                expect(res.status).toHaveBeenCalledWith(500);
+                expect(res.send).toHaveBeenCalledWith({ ok: false, error: "Order could not be saved" });
+                expect(res.json).not.toHaveBeenCalledWith({ ok: true });
+
+                consoleSpy.mockRestore();
             });
 
             it("should trigger catch block if try block throws", async () => {

--- a/tests/integration/payment/paymentIntegration.test.js
+++ b/tests/integration/payment/paymentIntegration.test.js
@@ -99,10 +99,11 @@ describe("brainTreePaymentController (integration)", () => {
       }),
       expect.any(Function)
     );
+    // Wait for the async callback's await .save() to complete
+    const saved = await waitForOrderByBuyer(buyerId);
     // 200 OK: controller uses res.json({ ok: true }) (Express default status 200)
     expect(res.json).toHaveBeenCalledWith({ ok: true });
     expect(res.status).not.toHaveBeenCalledWith(500);
-    const saved = await waitForOrderByBuyer(buyerId);
     expect(saved).not.toBeNull();
     expect(saved.payment).toMatchObject({ success: true, id: "fake-tx-id" });
     expect(String(saved.buyer)).toBe(String(buyerId));

--- a/tests/integration/product/payment.integration.test.js
+++ b/tests/integration/product/payment.integration.test.js
@@ -193,13 +193,18 @@ describe("Phase 2 [Middle]: brainTreePaymentController + orderModel + mocked Bra
     const res = createFakeResponse();
 
     await brainTreePaymentController(req, res);
-    await new Promise((r) => setImmediate(r));
-    await new Promise((r) => setImmediate(r));
 
     expect(mockSale).toHaveBeenCalled();
-    expect(res.json).toHaveBeenCalledWith({ ok: true });
 
-    const orders = await orderModel.find({ buyer: buyer._id });
+    // Wait for the async callback's await .save() to complete
+    const deadline = Date.now() + 5000;
+    let orders = [];
+    while (Date.now() < deadline) {
+      orders = await orderModel.find({ buyer: buyer._id });
+      if (orders.length > 0) break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(res.json).toHaveBeenCalledWith({ ok: true });
     expect(orders).toHaveLength(1);
     expect(orders[0].products).toHaveLength(1);
     expect(orders[0].payment.success).toBe(true);

--- a/tests/integration/product/product-details-category.integration.test.js
+++ b/tests/integration/product/product-details-category.integration.test.js
@@ -131,6 +131,7 @@ const chainableRes = () => {
   const res = {};
   res.status = jest.fn().mockReturnValue(res);
   res.send = jest.fn().mockReturnValue(res);
+  res.set = jest.fn().mockReturnValue(res);
   return res;
 };
 

--- a/tests/nft/recovery/db-recovery.test.js
+++ b/tests/nft/recovery/db-recovery.test.js
@@ -57,10 +57,6 @@ const createFakeRes = () => {
   return res;
 };
 
-/** Wait for the un-awaited order.save() to settle */
-const flushAsync = () =>
-  new Promise((r) => setTimeout(r, 200));
-
 const ensureConnected = async () => {
   if (mongoose.connection.readyState !== 1) {
     await mongoose.connect(mongoUri);
@@ -146,7 +142,7 @@ describe("Story 88 — DB / Internal Recovery", () => {
   // Test 1: DB disconnects during order save after payment
   // ----------------------------------------------------------
   describe("Test 1: DB disconnect during order save after successful payment", () => {
-    it("should handle DB failure during order save — server says ok but order is lost", async () => {
+    it("should return 500 when DB fails during order save after successful payment", async () => {
       // ms3
       // Lum Yi Ren Johannsen, A0273503L
 
@@ -162,21 +158,10 @@ describe("Story 88 — DB / Internal Recovery", () => {
       const res = createFakeRes();
 
       // Simulate DB failure by making orderModel.prototype.save reject.
-      // The controller's .save() is NOT awaited, so the rejection becomes
-      // an unhandled promise rejection (a real bug). We catch it here to
-      // prevent it from crashing the test runner, while proving the bug.
       const dbError = new Error("MongoNotConnectedError: simulated DB crash");
-      const savePromises = [];
       jest
         .spyOn(orderModel.prototype, "save")
-        .mockImplementation(function () {
-          // Return a promise that we control — catch it ourselves to prevent
-          // the unhandled rejection from bubbling to Jest
-          const p = Promise.reject(dbError);
-          p.catch(() => {}); // suppress unhandled rejection
-          savePromises.push(p);
-          return p;
-        });
+        .mockRejectedValue(dbError);
 
       // Mock Braintree to succeed — payment goes through
       mockSale.mockImplementation((opts, callback) => {
@@ -184,12 +169,11 @@ describe("Story 88 — DB / Internal Recovery", () => {
       });
 
       await brainTreePaymentController(req, res);
-      await flushAsync();
 
-      // BUG DEMONSTRATED: .save() is NOT awaited — the controller responds
-      // { ok: true } even though the order save failed / DB was down.
-      // The user is charged but the order is never recorded.
-      expect(res.json).toHaveBeenCalledWith({ ok: true });
+      // FIX VERIFIED: controller now awaits .save() and catches the error,
+      // returning 500 instead of a false { ok: true }
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).not.toHaveBeenCalledWith({ ok: true });
 
       // The save was called but rejected
       expect(orderModel.prototype.save).toHaveBeenCalled();

--- a/tests/nft/recovery/network-recovery.test.js
+++ b/tests/nft/recovery/network-recovery.test.js
@@ -54,10 +54,6 @@ const createFakeRes = () => {
   return res;
 };
 
-/** Wait for the un-awaited order.save() to settle */
-const flushAsync = () =>
-  new Promise((r) => setTimeout(r, 200));
-
 const waitForOrderByBuyer = async (buyerId, { timeoutMs = 5000 } = {}) => {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -199,7 +195,7 @@ describe("Story 89 — External / Network Recovery", () => {
       const res = createFakeRes();
 
       await brainTreePaymentController(req, res);
-      await flushAsync();
+
 
       // Should return 500
       expect(res.status).toHaveBeenCalledWith(500);
@@ -243,7 +239,7 @@ describe("Story 89 — External / Network Recovery", () => {
       const res = createFakeRes();
 
       await brainTreePaymentController(req, res);
-      await flushAsync();
+
 
       // Controller does `res.status(500).send(error)` where error is null
       expect(res.status).toHaveBeenCalledWith(500);
@@ -292,7 +288,7 @@ describe("Story 89 — External / Network Recovery", () => {
       const res1 = createFakeRes();
 
       await brainTreePaymentController(req1, res1);
-      await flushAsync();
+
 
       // Should fail
       expect(res1.status).toHaveBeenCalledWith(500);
@@ -314,13 +310,13 @@ describe("Story 89 — External / Network Recovery", () => {
       const res2 = createFakeRes();
 
       await brainTreePaymentController(req2, res2);
-      await flushAsync();
 
-      // Should succeed
-      expect(res2.json).toHaveBeenCalledWith({ ok: true });
-
-      // Wait for the un-awaited .save() to complete
+      // Wait for the async callback's await .save() to complete
       const savedOrder = await waitForOrderByBuyer(testUser._id);
+
+      // Should succeed — check after order is persisted since the
+      // async callback needs time to await .save() then call res.json
+      expect(res2.json).toHaveBeenCalledWith({ ok: true });
       expect(savedOrder).not.toBeNull();
       expect(savedOrder.payment).toMatchObject({
         success: true,


### PR DESCRIPTION
## Summary
  - Await `orderModel.save()` in `brainTreePaymentController` and add try/catch — DB failures now
  return 500 instead of a false `{ ok: true }`
  - Add unit test for the new catch block to maintain 100% backend coverage
  - Update `db-recovery.test.js` Test 1 to assert the fix (expect 500, not success)
  - Remove `flushAsync` from recovery tests — no longer needed since save is awaited
  - Adjust assertion order in payment integration tests to wait for the async callback
  - Fix pre-existing `res.set` mock issue in `product-details-category.integration.test.js`

  ## Test plan
  - [ ] `npx jest --config jest.nft.config.js` — 8/8 recovery tests pass
  - [ ] `npm run test:integration` — 169/169 pass
  - [ ] `npm run test:backend` — all pass with 100% coverage on productController.js